### PR TITLE
List all files

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -246,7 +246,7 @@ class CloudinaryAdapter implements AdapterInterface
                 'type' => 'upload',
                 'prefix' => $directory,
                 'max_results' => 500,
-                'next_cursor' => $response['next_cursor'] ?? null,
+                'next_cursor' => isset($response['next_cursor']) ? $response['next_cursor'] : null,
             ]);
             $resources = array_merge($resources, $response['resources']);
         } while (array_key_exists('next_cursor', $response));

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -9,6 +9,7 @@ use Cloudinary\Uploader;
 use League\Flysystem\Config;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Adapter\Polyfill\NotSupportingVisibilityTrait;
+
 /**
  *
  */
@@ -236,11 +237,20 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function listContents($directory = '', $hasRecursive = false)
     {
+        $resources = [];
+
         // get resources array
-        $resources = ((array) $this->api->resources([
-            'type' => 'upload',
-            'prefix' => $directory
-        ])['resources']);
+        $response = null;
+        do {
+            $response = (array) $this->api->resources([
+                'type' => 'upload',
+                'prefix' => $directory,
+                'max_results' => 500,
+                'next_cursor' => $response['next_cursor'] ?? null,
+            ]);
+            $resources = array_merge($resources, $response['resources']);
+        } while (array_key_exists('next_cursor', $response));
+
         // parse resourses
         foreach ($resources as $i => $resource) {
             $resources[$i] = $this->prepareResourceMetadata($resource);

--- a/tests/CloudinaryAdapterTest.php
+++ b/tests/CloudinaryAdapterTest.php
@@ -6,7 +6,6 @@
  * Time: 13:40
  */
 
-
 include_once __DIR__ .'/../vendor/autoload.php';
 
 use CarlosOCarvalho\Flysystem\Cloudinary\CloudinaryAdapter as Adapter;
@@ -14,18 +13,17 @@ use CarlosOCarvalho\Flysystem\Cloudinary\CloudinaryAdapter as Adapter;
 class CloudinaryAdapterTest extends PHPUnit_Framework_TestCase
 {
 
-  private  $cloudinary;
+    private $cloudinary;
 
-  function  setUp()
-  {
-     $config = ['key'=>':key'];
-     $this->cloudinary = new Adapter($config);
-  }
-
-
-  public function testFailure(){
-      $this->assertInstanceOf('CarlosOCarvalho\Flysystem\Cloudinary\CloudinaryAdapter', $this->cloudinary );
-  }
+    public function setUp()
+    {
+        $config = ['key' => ':key'];
+        $this->cloudinary = new Adapter($config);
+    }
 
 
+    public function testFailure()
+    {
+        $this->assertInstanceOf('CarlosOCarvalho\Flysystem\Cloudinary\CloudinaryAdapter', $this->cloudinary);
+    }
 }


### PR DESCRIPTION
This PR changes the behavior of `listContents` function which only returns 10 items. 
https://cloudinary.com/documentation/admin_api#pagination

This solution makes use of `max_results` and `next_cursor` parameters to retrieve all items.
