### PR TITLE
Ability to pass `format` parameter

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -107,6 +107,7 @@ class CloudinaryAdapter implements FilesystemAdapter
     {
         $public_id = $options->get('public_id', $path);
         $resource_type = $options->get('resource_type', 'auto');
+        $format = $options->get('format', null);
         $resourceMetadata = stream_get_meta_data($resource);
 
         $uploadedMetadata = $this->uploadApi->upload(
@@ -114,6 +115,7 @@ class CloudinaryAdapter implements FilesystemAdapter
             [
                 'public_id' => $public_id,
                 'resource_type' => $resource_type,
+                'format' => $format
             ]
         );
     }


### PR DESCRIPTION
With this it is possible to force the Adapter to save the incoming file in a specific format. This makes sense if you want to upload svg files. These are actually xml files and wont get recognized by cloudinary as images if it is not being told to do so.